### PR TITLE
Apply naming conventions for propositional logic

### DIFF
--- a/engine/src/prop/formula.rs
+++ b/engine/src/prop/formula.rs
@@ -1,12 +1,18 @@
 //! Formulas of propositional logic
 
+/// A formula of propositional logic.
 #[derive(Debug, Clone)]
 pub enum Formula {
-    Var(String),
+    /// An atomic proposition symbol.
+    Prop(String),
+
+    /// A unary connective.
     Unary {
         connective: UnaryConnective,
         arg: Box<Formula>,
     },
+
+    /// A binary connective.
     Binary {
         connective: BinaryConnective,
         lhs: Box<Formula>,
@@ -16,12 +22,18 @@ pub enum Formula {
 
 #[derive(Debug, Clone, Copy)]
 pub enum UnaryConnective {
+    /// Negation.
     Not,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum BinaryConnective {
+    /// Conjunction.
     And,
+
+    /// Disjunction.
     Or,
+
+    /// Implication.
     Imp,
 }

--- a/engine/src/prop/parser/formula.rs
+++ b/engine/src/prop/parser/formula.rs
@@ -4,7 +4,7 @@ use chumsky::prelude::*;
 use crate::prop::formula::{BinaryConnective, Formula, UnaryConnective};
 
 use super::lexer::Token;
-use super::settings::{ParenthesizationStyle, ParsingSettings};
+use super::settings::{ParenStyle, ParsingSettings};
 
 /// Parses a formula of propositional logic.
 pub fn formula_parser<'tok, I>(
@@ -13,9 +13,9 @@ pub fn formula_parser<'tok, I>(
 where
     I: ValueInput<'tok, Token = Token, Span = SimpleSpan>,
 {
-    match settings.parenthesization_style {
-        ParenthesizationStyle::Strict => formula_strict().boxed(),
-        ParenthesizationStyle::Lax => formula_lax().boxed(),
+    match settings.paren_style {
+        ParenStyle::Strict => formula_strict().boxed(),
+        ParenStyle::Lax => formula_lax().boxed(),
     }
 }
 
@@ -25,7 +25,7 @@ where
     I: ValueInput<'tok, Token = Token, Span = SimpleSpan>,
 {
     recursive(|formula| {
-        let var = select! { Token::Var(var) => Formula::Var(var) };
+        let prop = select! { Token::Prop(prop) => Formula::Prop(prop) };
 
         let unary = unary_connective()
             .then(formula.clone())
@@ -45,7 +45,7 @@ where
                 rhs: Box::new(rhs),
             });
 
-        choice((var, unary, binary))
+        choice((prop, unary, binary))
     })
 }
 

--- a/engine/src/prop/parser/lexer.rs
+++ b/engine/src/prop/parser/lexer.rs
@@ -1,7 +1,7 @@
 use chumsky::prelude::*;
 use chumsky::text::{ident, keyword};
 
-use super::settings::{ParsingSettings, VariableStyle};
+use super::settings::{ParsingSettings, PropStyle};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
@@ -15,7 +15,7 @@ pub enum Token {
     Imp,
     Not,
 
-    Var(String),
+    Prop(String),
 }
 
 pub fn lexer<'src>(
@@ -32,31 +32,31 @@ pub fn lexer<'src>(
         choice((just("→"), keyword("not"), just("~"), just("!"))).to(Token::Not),
     ));
 
-    let var = variable(settings);
+    let prop = proposition(settings);
 
     simple
-        .or(var)
+        .or(prop)
         .padded()
         .recover_with(skip_then_retry_until(any().ignored(), end()))
         .repeated()
         .collect()
 }
 
-fn variable<'src>(
+fn proposition<'src>(
     settings: &ParsingSettings,
 ) -> impl Parser<'src, &'src str, Token, extra::Err<Rich<'src, char>>> {
-    let var_matcher = match settings.variable_style {
-        VariableStyle::Letter => any().map(|c: char| c.to_string()).boxed(),
-        VariableStyle::UpperLetter => any()
+    let prop_matcher = match settings.prop_style {
+        PropStyle::Letter => any().map(|c: char| c.to_string()).boxed(),
+        PropStyle::UpperLetter => any()
             .filter(|c: &char| c.is_uppercase())
             .map(|c| c.to_string())
             .boxed(),
-        VariableStyle::LowerLetter => any()
+        PropStyle::LowerLetter => any()
             .filter(|c: &char| c.is_lowercase())
             .map(|c| c.to_string())
             .boxed(),
-        VariableStyle::Ident => ident().map(|s: &str| s.to_string()).boxed(),
+        PropStyle::Ident => ident().map(|s: &str| s.to_string()).boxed(),
     };
 
-    var_matcher.map(Token::Var)
+    prop_matcher.map(Token::Prop)
 }

--- a/engine/src/prop/parser/settings.rs
+++ b/engine/src/prop/parser/settings.rs
@@ -1,31 +1,31 @@
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParsingSettings {
-    pub variable_style: VariableStyle,
-    pub parenthesization_style: ParenthesizationStyle,
+    pub prop_style: PropStyle,
+    pub paren_style: ParenStyle,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub enum VariableStyle {
-    /// Variables are single letters
+pub enum PropStyle {
+    /// Proposition symbols are single letters.
     #[default]
     Letter,
 
-    /// Variables are single uppercase letters
+    /// Proposition symbols are single uppercase letters.
     UpperLetter,
 
-    /// Variables are single lowercase letters
+    /// Proposition symbols are single lowercase letters.
     LowerLetter,
 
-    /// Variables are C-style identifiers
+    /// Proposition symbols are C-style identifiers.
     Ident,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-pub enum ParenthesizationStyle {
-    /// Every subformula must be parenthesized
+pub enum ParenStyle {
+    /// Every subformula must be parenthesized.
     Strict,
 
-    /// Outermost parentheses can be omitted
+    /// Outermost parentheses can be omitted.
     #[default]
     Lax,
 }


### PR DESCRIPTION
Rename some stuff consistently and add comments.